### PR TITLE
Handle drops for #[const_continue]

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -362,9 +362,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 );
 
                                 this.in_const_continuable_scope(
-                                    loop_block,
                                     targets.clone(),
                                     state_place,
+                                    expr_span,
                                     |this| {
                                         let discr = this.temp(discr_ty, source_info.span);
                                         this.cfg.push_assign(

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -404,8 +404,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                                 TerminatorKind::Unreachable,
                                             );
                                         }
-
-                                        None
                                     },
                                 )
                             }

--- a/loop_match_todo.md
+++ b/loop_match_todo.md
@@ -1,11 +1,11 @@
 # TODO
 
 * [x] errors instead of ICE on incorrect usage
-* [ ] deny drop for `#[const_continue]`
 * [x] integer patterns
 * [x] `_` and `Foo | Bar` patterns
-* [ ] handle in the `let mut` checker (likely needs handling drop trees for StorageDead)
+* [x] handle in the `let mut` checker (likely needs handling drop trees for StorageDead)
 * [ ] `lint_level`?
 * [ ] test if nested `#[loop_match]` with `#[const_continue]` operating on outer loop works
 * [x] deny attributes on the wrong items
     * [ ] add test
+* [ ] fix crash for `match self.bit_reader.bits(2) {}` in zlib-rs

--- a/tests/ui/loop-match/loop-match.rs
+++ b/tests/ui/loop-match/loop-match.rs
@@ -20,7 +20,7 @@ fn main() {
                     break 'blk State::B
                 }
                 State::B => {
-                    //let _a = 0;
+                    let _a = 0;
                     if true {
                         #[const_continue]
                         break 'blk State::C;


### PR DESCRIPTION
This is necessary to prevent borrowck from considering all non-mut lets inside the loop match as reassignments of immutable variables.

Not really happy with the code quality, but it works for now.