### PR TITLE
Loop match lint level

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -368,9 +368,8 @@ pub enum ExprKind<'tcx> {
         state: ExprId,
 
         region_scope: region::Scope,
-        //lint_level: LintLevel,
+        // lint_level: LintLevel,
         arms: Box<[ArmId]>,
-        match_source: MatchSource,
     },
     /// Special expression representing the `let` part of an `if let` or similar construct
     /// (including `if let` guards in match arms, and let-chains formed by `&&`).

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -368,7 +368,6 @@ pub enum ExprKind<'tcx> {
         state: ExprId,
 
         region_scope: region::Scope,
-        // lint_level: LintLevel,
         arms: Box<[ArmId]>,
     },
     /// Special expression representing the `let` part of an `if let` or similar construct

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -251,22 +251,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let dropless_arena = rustc_arena::DroplessArena::default();
                 let typeck_results = this.tcx.typeck(this.def_id);
 
-                // FIXME use the lint level from `ExprKind::LoopMatch`
-                let lint_level = this.tcx.local_def_id_to_hir_id(this.def_id);
-
                 // the PatCtxt is normally used in pattern exhaustiveness checking, but reused here
                 // because it performs normalization and const evaluation.
                 let cx = RustcPatCtxt {
                     tcx: this.tcx,
                     typeck_results,
-                    module: this.tcx.parent_module(lint_level).to_def_id(),
+                    module: this.tcx.parent_module(this.hir_id).to_def_id(),
                     // FIXME(#132279): We're in a body, should handle opaques.
                     typing_env: rustc_middle::ty::TypingEnv::non_body_analysis(
                         this.tcx,
                         this.def_id,
                     ),
                     dropless_arena: &dropless_arena,
-                    match_lint_level: lint_level,
+                    match_lint_level: this.hir_id,
                     whole_match_span: Some(rustc_span::Span::default()),
                     scrut_span: rustc_span::Span::default(),
                     refutable: true,

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -896,7 +896,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                         dcx.emit_fatal(LoopMatchBadRhs { span: block_body.span })
                     };
 
-                    let hir::ExprKind::Match(scrutinee, arms, match_source) = block_body_expr.kind
+                    let hir::ExprKind::Match(scrutinee, arms, _match_source) = block_body_expr.kind
                     else {
                         dcx.emit_fatal(LoopMatchBadRhs { span: block_body_expr.span })
                     };
@@ -930,7 +930,6 @@ impl<'tcx> ThirBuildCx<'tcx> {
                         },
 
                         arms: arms.iter().map(|a| self.convert_arm(a)).collect(),
-                        match_source,
                     }
                 } else {
                     let block_ty = self.typeck_results.node_type(body.hir_id);

--- a/loop_match_todo.md
+++ b/loop_match_todo.md
@@ -4,7 +4,7 @@
 * [x] integer patterns
 * [x] `_` and `Foo | Bar` patterns
 * [x] handle in the `let mut` checker (likely needs handling drop trees for StorageDead)
-* [ ] `lint_level`?
+* [x] `lint_level`?
 * [x] test if nested `#[loop_match]` with `#[const_continue]` operating on outer loop works
 * [x] deny attributes on the wrong items
     * [ ] add test


### PR DESCRIPTION
As far as I can tell, just using the hir id of the `LoopMatch` is sufficient, and it does not really make sense to store that value separately if we can just retrieve it from the builder. 
