### PR TITLE
open a new scope for `SwitchInt` arms

### DIFF
--- a/loop_match_todo.md
+++ b/loop_match_todo.md
@@ -8,4 +8,4 @@
 * [x] test if nested `#[loop_match]` with `#[const_continue]` operating on outer loop works
 * [x] deny attributes on the wrong items
     * [ ] add test
-* [ ] fix crash for `match self.bit_reader.bits(2) {}` in zlib-rs
+* [x] fix crash for `match self.bit_reader.bits(2) {}` in zlib-rs

--- a/tests/ui/loop-match/drop-in-match-arm.rs
+++ b/tests/ui/loop-match/drop-in-match-arm.rs
@@ -1,0 +1,32 @@
+//@ run-pass
+
+#![feature(loop_match)]
+
+// test that drops work in match arms (match arms need their own scope)
+
+fn main() {
+    assert_eq!(helper(), 1);
+}
+
+struct X;
+
+impl Drop for X {
+    fn drop(&mut self) {}
+}
+
+#[no_mangle]
+#[inline(never)]
+fn helper() -> i32 {
+    let mut state = 0;
+    #[loop_match]
+    'a: loop {
+        state = 'blk: {
+            match state {
+                0 => match X {
+                    _ => break 'blk 1,
+                },
+                _ => break 'a state,
+            }
+        };
+    }
+}


### PR DESCRIPTION
that's kind of on us for trying to replicate the pattern matching codegen logic. 
