### PR TITLE
use more pattern match infra

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -278,9 +278,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // Start the loop.
                 this.cfg.goto(block, source_info, loop_block);
 
-                // FIXME do we need the breakable scope?
                 this.in_breakable_scope(Some(loop_block), destination, expr_span, |this| {
-                    // conduct the test, if necessary
                     let mut body_block = this.cfg.start_new_block();
                     this.cfg.terminate(
                         loop_block,

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -1,6 +1,5 @@
 //! See docs in build/expr/mod.rs
 
-use rustc_abi::VariantIdx;
 use rustc_ast::{AsmMacro, InlineAsmOptions};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stack::ensure_sufficient_stack;
@@ -9,17 +8,14 @@ use rustc_hir::lang_items::LangItem;
 use rustc_middle::mir::*;
 use rustc_middle::span_bug;
 use rustc_middle::thir::*;
-use rustc_middle::ty::util::Discr;
 use rustc_middle::ty::{CanonicalUserTypeAnnotation, Ty};
-use rustc_pattern_analysis::constructor::Constructor;
-use rustc_pattern_analysis::rustc::{DeconstructedPat, RustcPatCtxt};
 use rustc_span::DUMMY_SP;
 use rustc_span::source_map::Spanned;
 use rustc_trait_selection::infer::InferCtxtExt;
 use tracing::{debug, instrument};
 
 use crate::builder::expr::category::{Category, RvalueFunc};
-use crate::builder::matches::DeclareLetBindings;
+use crate::builder::matches::{DeclareLetBindings, HasMatchGuard};
 use crate::builder::{BlockAnd, BlockAndExtension, BlockFrame, Builder, NeedsTemporary};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
@@ -251,28 +247,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::LoopMatch { state, region_scope, ref arms } => {
                 // FIXME add diagram
 
-                let dropless_arena = rustc_arena::DroplessArena::default();
-                let typeck_results = this.tcx.typeck(this.def_id);
-
-                // the PatCtxt is normally used in pattern exhaustiveness checking, but reused here
-                // because it performs normalization and const evaluation.
-                let cx = RustcPatCtxt {
-                    tcx: this.tcx,
-                    typeck_results,
-                    module: this.tcx.parent_module(this.hir_id).to_def_id(),
-                    // FIXME(#132279): We're in a body, should handle opaques.
-                    typing_env: rustc_middle::ty::TypingEnv::non_body_analysis(
-                        this.tcx,
-                        this.def_id,
-                    ),
-                    dropless_arena: &dropless_arena,
-                    match_lint_level: this.hir_id,
-                    whole_match_span: Some(rustc_span::Span::default()),
-                    scrut_span: rustc_span::Span::default(),
-                    refutable: true,
-                    known_valid_scrutinee: true,
-                };
-
                 let loop_block = this.cfg.start_new_block();
 
                 // Start the loop.
@@ -290,131 +264,52 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     );
                     this.diverge_from(loop_block);
 
-                    let state_place = unpack!(body_block = this.as_place(body_block, state));
-                    let state_ty = this.thir.exprs[state].ty;
+                    let scrutinee_place_builder =
+                        unpack!(body_block = this.as_place_builder(body_block, state));
+                    let scrutinee_span = this.thir.exprs[state].span;
+                    let match_start_span = scrutinee_span; // span.shrink_to_lo().to(scrutinee_span); FIXME
+                    let patterns = arms
+                        .iter()
+                        .map(|&arm_id| {
+                            // FIXME nice error for guards (which are not allowed)
+                            let arm = &this.thir[arm_id];
+                            assert!(arm.guard.is_none());
+                            (&*arm.pattern, HasMatchGuard::No)
+                        })
+                        .collect();
 
-                    // the type of the value that is switched on by the `SwitchInt`
-                    let discr_ty = match state_ty {
-                        ty if ty.is_enum() => ty.discriminant_ty(this.tcx),
-                        ty if ty.is_integral() => ty,
-                        other => todo!("{other:?}"),
-                    };
+                    let built_tree = this.lower_match_tree(
+                        body_block,
+                        scrutinee_span,
+                        &scrutinee_place_builder,
+                        match_start_span,
+                        patterns,
+                        false,
+                    );
 
-                    let rvalue = match state_ty {
-                        ty if ty.is_enum() => Rvalue::Discriminant(state_place),
-                        ty if ty.is_integral() => Rvalue::Use(Operand::Copy(state_place)),
-                        _ => todo!(),
-                    };
-
-                    // block and arm of the wildcard pattern (if any)
-                    let mut otherwise = None;
+                    let state_place = scrutinee_place_builder.to_place(this);
 
                     unpack!(
                         body_block = this.in_scope(
                             (region_scope, source_info),
                             LintLevel::Inherited,
                             move |this| {
-                                let mut arm_blocks = Vec::with_capacity(arms.len());
-                                for &arm in arms {
-                                    let pat = &this.thir[arm].pattern;
-
-                                    this.loop_match_patterns(
-                                        arm,
-                                        &cx.lower_pat(pat),
-                                        None,
-                                        &mut arm_blocks,
-                                        &mut otherwise,
-                                    );
-                                }
-
-                                // handle patterns like `None | None` or two different arms that
-                                // have the same pattern.
-                                //
-                                // NOTE: why this works is a bit subtle: we always want to pick the
-                                // first arm for a pattern, and because this is a stable sort that
-                                // works out.
-                                arm_blocks.sort_by_key(|(_, discr, _, _)| discr.val);
-                                arm_blocks.dedup_by_key(|(_, discr, _, _)| discr.val);
-
-                                // if we're matching on an enum, the discriminant order in the `SwitchInt`
-                                // targets should match the order yielded by `AdtDef::discriminants`.
-                                if state_ty.is_enum() {
-                                    arm_blocks.sort_by_key(|(variant_idx, ..)| *variant_idx);
-                                }
-
-                                let targets = SwitchTargets::new(
-                                    arm_blocks
-                                        .iter()
-                                        .map(|&(_, discr, block, _arm)| (discr.val, block)),
-                                    if let Some((block, _)) = otherwise {
-                                        block
-                                    } else {
-                                        let unreachable_block = this.cfg.start_new_block();
-                                        this.cfg.terminate(
-                                            unreachable_block,
-                                            source_info,
-                                            TerminatorKind::Unreachable,
-                                        );
-                                        unreachable_block
-                                    },
-                                );
-
                                 this.in_breakable_scope(None, state_place, expr_span, |this| {
                                     Some(this.in_const_continuable_scope(
-                                        targets.clone(),
+                                        arms.clone(),
+                                        built_tree.clone(),
                                         state_place,
                                         expr_span,
                                         |this| {
-                                            let discr = this.temp(discr_ty, source_info.span);
-                                            this.cfg.push_assign(
-                                                body_block,
-                                                source_info,
-                                                discr,
-                                                rvalue,
-                                            );
-                                            let discr = Operand::Copy(discr);
-                                            this.cfg.terminate(
-                                                body_block,
-                                                source_info,
-                                                TerminatorKind::SwitchInt { discr, targets },
-                                            );
-
-                                            let it = arm_blocks
-                                                .into_iter()
-                                                .map(|(_, _, block, arm)| (block, arm))
-                                                .chain(otherwise);
-
-                                            for (mut block, arm_id) in it {
-                                                if this.cfg.block_data(block).terminator.is_some() {
-                                                    continue; // this can occur with or-patterns
-                                                }
-
-                                                let arm = &this.thir[arm_id];
-                                                let arm_source_info = this.source_info(arm.span);
-                                                let arm_scope = (arm.scope, arm_source_info);
-
-                                                let empty_place = this.get_unit_temp();
-                                                unpack!(
-                                                    block = {
-                                                        this.in_scope(
-                                                            arm_scope,
-                                                            arm.lint_level,
-                                                            |this| {
-                                                                this.expr_into_dest(
-                                                                    empty_place,
-                                                                    block,
-                                                                    arm.body,
-                                                                )
-                                                            },
-                                                        )
-                                                    }
-                                                );
-                                                this.cfg.terminate(
-                                                    block,
-                                                    source_info,
-                                                    TerminatorKind::Unreachable,
-                                                );
-                                            }
+                                            this.lower_match_arms(
+                                                destination,
+                                                scrutinee_place_builder,
+                                                scrutinee_span,
+                                                arms,
+                                                built_tree,
+                                                // FIXME this should be the span of just the match
+                                                this.source_info(expr_span),
+                                            )
                                         },
                                     ))
                                 })
@@ -891,57 +786,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Let { .. } => true,
             ExprKind::Scope { value, .. } => self.is_let(value),
             _ => false,
-        }
-    }
-
-    fn loop_match_patterns(
-        &mut self,
-        arm_id: ArmId,
-        pat: &DeconstructedPat<'_, 'tcx>,
-        current_block: Option<BasicBlock>,
-        result: &mut Vec<(VariantIdx, Discr<'tcx>, BasicBlock, ArmId)>,
-        otherwise: &mut Option<(BasicBlock, ArmId)>,
-    ) {
-        match pat.ctor() {
-            Constructor::Variant(variant_index) => {
-                let PatKind::Variant { adt_def, .. } = pat.data().kind else { unreachable!() };
-
-                let discr = adt_def.discriminant_for_variant(self.tcx, *variant_index);
-
-                let block = current_block.unwrap_or_else(|| self.cfg.start_new_block());
-                result.push((*variant_index, discr, block, arm_id));
-            }
-            Constructor::IntRange(int_range) => {
-                assert!(int_range.is_singleton());
-
-                let bits = pat.ty().primitive_size(self.tcx).bits();
-
-                let value = if pat.ty().is_signed() {
-                    int_range.lo.as_finite_int(bits).unwrap()
-                } else {
-                    int_range.lo.as_finite_uint().unwrap()
-                };
-
-                let discr = Discr { val: value, ty: **pat.ty() };
-
-                let block = current_block.unwrap_or_else(|| self.cfg.start_new_block());
-                result.push((VariantIdx::ZERO, discr, block, arm_id));
-            }
-            Constructor::Wildcard => {
-                // the first wildcard wins
-                if otherwise.is_none() {
-                    let block = current_block.unwrap_or_else(|| self.cfg.start_new_block());
-                    *otherwise = Some((block, arm_id))
-                }
-            }
-            Constructor::Or => {
-                let block = current_block.unwrap_or_else(|| self.cfg.start_new_block());
-
-                for indexed in pat.iter_fields() {
-                    self.loop_match_patterns(arm_id, &indexed.pat, Some(block), result, otherwise);
-                }
-            }
-            other => todo!("{:?}", other),
         }
     }
 }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -11,6 +11,7 @@ use std::mem;
 use std::sync::Arc;
 
 use rustc_abi::VariantIdx;
+use rustc_ast::LitKind;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir::{BindingMode, ByRef};
@@ -19,6 +20,7 @@ use rustc_middle::middle::region;
 use rustc_middle::mir::{self, *};
 use rustc_middle::thir::{self, *};
 use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty};
+use rustc_pattern_analysis::rustc::{DeconstructedPat, RustcPatCtxt};
 use rustc_span::{BytePos, Pos, Span, Symbol};
 use tracing::{debug, instrument};
 
@@ -426,7 +428,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// (by [Builder::lower_match_tree]).
     ///
     /// `outer_source_info` is the SourceInfo for the whole match.
-    fn lower_match_arms(
+    pub(crate) fn lower_match_arms(
         &mut self,
         destination: Place<'tcx>,
         scrutinee_place_builder: PlaceBuilder<'tcx>,
@@ -1388,7 +1390,7 @@ pub(crate) struct ArmHasGuard(pub(crate) bool);
 /// A sub-branch in the output of match lowering. Match lowering has generated MIR code that will
 /// branch to `success_block` when the matched value matches the corresponding pattern. If there is
 /// a guard, its failure must continue to `otherwise_block`, which will resume testing patterns.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct MatchTreeSubBranch<'tcx> {
     span: Span,
     /// The block that is branched to if the corresponding subpattern matches.
@@ -1404,7 +1406,7 @@ struct MatchTreeSubBranch<'tcx> {
 }
 
 /// A branch in the output of match lowering.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct MatchTreeBranch<'tcx> {
     sub_branches: Vec<MatchTreeSubBranch<'tcx>>,
 }
@@ -1423,8 +1425,8 @@ struct MatchTreeBranch<'tcx> {
 /// Here the first arm gives the first `MatchTreeBranch`, which has two sub-branches, one for each
 /// alternative of the or-pattern. They are kept separate because each needs to bind `x` to a
 /// different place.
-#[derive(Debug)]
-struct BuiltMatchTree<'tcx> {
+#[derive(Debug, Clone)]
+pub(crate) struct BuiltMatchTree<'tcx> {
     branches: Vec<MatchTreeBranch<'tcx>>,
     otherwise_block: BasicBlock,
     /// If any of the branches had a guard, we collect here the places and locals to fakely borrow
@@ -1482,7 +1484,7 @@ impl<'tcx> MatchTreeBranch<'tcx> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HasMatchGuard {
+pub(crate) enum HasMatchGuard {
     Yes,
     No,
 }
@@ -1497,7 +1499,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// `refutable` indicates whether the candidate list is refutable (for `if let` and `let else`)
     /// or not (for `let` and `match`). In the refutable case we return the block to which we branch
     /// on failure.
-    fn lower_match_tree(
+    pub(crate) fn lower_match_tree(
         &mut self,
         block: BasicBlock,
         scrutinee_span: Span,
@@ -2828,5 +2830,82 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         };
         debug!(?locals);
         self.var_indices.insert(var_id, locals);
+    }
+
+    /// Attempt to statically pick the BasicBlock that a value would resolve to at runtime.
+    pub(crate) fn static_pattern_match(
+        &self,
+        cx: &RustcPatCtxt<'_, 'tcx>,
+        value: ExprId,
+        arms: &[ArmId],
+        built_match_tree: &BuiltMatchTree<'tcx>,
+    ) -> Option<BasicBlock> {
+        let it = arms.iter().zip(built_match_tree.branches.iter());
+        for (&arm_id, branch) in it {
+            let pat = cx.lower_pat(&*self.thir.arms[arm_id].pattern);
+
+            if let rustc_pattern_analysis::rustc::Constructor::Or = pat.ctor() {
+                for pat in pat.iter_fields() {
+                    // when the bindings are the same, the sub_branch is only stored once,
+                    // so we must repeat it manually.
+                    let sub_branch = branch
+                        .sub_branches
+                        .get(pat.idx)
+                        .or_else(|| branch.sub_branches.last())
+                        .unwrap();
+
+                    match self.static_pattern_match_help(value, &pat.pat) {
+                        true => return Some(sub_branch.success_block),
+                        false => continue,
+                    }
+                }
+            } else if self.static_pattern_match_help(value, &pat) {
+                return Some(branch.sub_branches[0].success_block);
+            }
+        }
+
+        None
+    }
+
+    fn static_pattern_match_help(&self, value: ExprId, pat: &DeconstructedPat<'_, 'tcx>) -> bool {
+        use rustc_middle::thir::ExprKind;
+        use rustc_pattern_analysis::constructor::{IntRange, MaybeInfiniteInt};
+        use rustc_pattern_analysis::rustc::Constructor;
+
+        match pat.ctor() {
+            Constructor::Variant(variant_index) => match &self.thir[value].kind {
+                ExprKind::Adt(value_adt) => {
+                    return *variant_index == value_adt.variant_index;
+                }
+                other => todo!("{other:?}"),
+            },
+            Constructor::IntRange(int_range) => match &self.thir[value].kind {
+                ExprKind::Literal { lit, neg } => match &lit.node {
+                    LitKind::Int(n, _) => {
+                        let n = if pat.ty().is_signed() {
+                            let bits = pat.ty().primitive_size(self.tcx).bits();
+                            MaybeInfiniteInt::new_finite_int(
+                                if *neg {
+                                    (n.get() as i128).overflowing_neg().0 as u128
+                                        & ((1u128 << bits) - 1)
+                                } else {
+                                    n.get()
+                                },
+                                bits,
+                            )
+                        } else {
+                            MaybeInfiniteInt::new_finite_uint(n.get())
+                        };
+
+                        return IntRange::from_singleton(n).is_subrange(int_range);
+                    }
+
+                    other => todo!("{other:?}"),
+                },
+                other => todo!("{other:?}"),
+            },
+            Constructor::Wildcard => return true,
+            _ => false,
+        }
     }
 }

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -83,19 +83,20 @@ that contains only loops and breakable blocks. It tracks where a `break`,
 
 use std::mem;
 
-use rustc_ast::LitKind;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::HirId;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
-use rustc_middle::thir::{ExprId, LintLevel};
+use rustc_middle::thir::{ArmId, ExprId, LintLevel};
 use rustc_middle::{bug, span_bug};
+use rustc_pattern_analysis::rustc::RustcPatCtxt;
 use rustc_session::lint::Level;
 use rustc_span::source_map::Spanned;
 use rustc_span::{DUMMY_SP, Span};
 use tracing::{debug, instrument};
 
+use super::matches::BuiltMatchTree;
 use crate::builder::{BlockAnd, BlockAndExtension, BlockFrame, Builder, CFG};
 
 #[derive(Debug)]
@@ -184,7 +185,9 @@ struct ConstContinuableScope<'tcx> {
     /// the result of a `break` or `return` expression)
     state_place: Place<'tcx>,
 
-    match_arms: SwitchTargets,
+    arms: Box<[ArmId]>,
+    built_match_tree: BuiltMatchTree<'tcx>,
+
     /// Drops that happen on the `return` path and would have happened on the `break` path.
     break_drops: DropTree,
 }
@@ -572,32 +575,48 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// branch to.
     pub(crate) fn in_const_continuable_scope<F>(
         &mut self,
-        match_arms: SwitchTargets,
+        arms: Box<[ArmId]>,
+        built_match_tree: BuiltMatchTree<'tcx>,
         state_place: Place<'tcx>,
         span: Span,
         f: F,
     ) -> BlockAnd<()>
     where
-        F: FnOnce(&mut Builder<'a, 'tcx>),
+        F: FnOnce(&mut Builder<'a, 'tcx>) -> BlockAnd<()>,
     {
         let region_scope = self.scopes.topmost();
         let scope = ConstContinuableScope {
             region_scope,
             state_place,
             break_drops: DropTree::new(),
-            match_arms,
+            arms,
+            built_match_tree,
         };
         self.scopes.const_continuable_scopes.push(scope);
-        f(self);
+        let normal_exit_block = f(self);
         let breakable_scope = self.scopes.const_continuable_scopes.pop().unwrap();
         assert!(breakable_scope.region_scope == region_scope);
 
         let break_block =
             self.build_exit_tree(breakable_scope.break_drops, region_scope, span, None);
 
-        match break_block {
-            Some(block) => block,
-            None => self.cfg.start_new_block().unit(),
+        match (normal_exit_block, break_block) {
+            (block, None) => block,
+            (normal_block, Some(exit_block)) => {
+                let target = self.cfg.start_new_block();
+                let source_info = self.source_info(span);
+                self.cfg.terminate(
+                    normal_block.into_block(),
+                    source_info,
+                    TerminatorKind::Goto { target },
+                );
+                self.cfg.terminate(
+                    exit_block.into_block(),
+                    source_info,
+                    TerminatorKind::Goto { target },
+                );
+                target.unit()
+            }
         }
     }
 
@@ -764,23 +783,32 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     _ => todo!(),
                 };
 
-                let real_target = match &self.thir[value].kind {
-                    rustc_middle::thir::ExprKind::Adt(value_adt) => scope
-                        .match_arms
-                        .target_for_value(u128::from(value_adt.variant_index.as_u32())),
-                    rustc_middle::thir::ExprKind::Literal { lit, neg } => match lit.node {
-                        LitKind::Int(n, _) => {
-                            let n = if *neg {
-                                (n.get() as i128).overflowing_neg().0 as u128
-                            } else {
-                                n.get()
-                            };
-                            let result = state_ty.primitive_size(self.tcx).truncate(n);
-                            scope.match_arms.target_for_value(result)
-                        }
-                        _ => todo!(),
-                    },
-                    other => todo!("{other:?}"),
+                // the PatCtxt is normally used in pattern exhaustiveness checking, but reused here
+                // because it performs normalization and const evaluation.
+                let dropless_arena = rustc_arena::DroplessArena::default();
+                let typeck_results = self.tcx.typeck(self.def_id);
+                let cx = RustcPatCtxt {
+                    tcx: self.tcx,
+                    typeck_results,
+                    module: self.tcx.parent_module(self.hir_id).to_def_id(),
+                    // FIXME(#132279): We're in a body, should handle opaques.
+                    typing_env: rustc_middle::ty::TypingEnv::non_body_analysis(
+                        self.tcx,
+                        self.def_id,
+                    ),
+                    dropless_arena: &dropless_arena,
+                    match_lint_level: self.hir_id,
+                    whole_match_span: Some(rustc_span::Span::default()),
+                    scrut_span: rustc_span::Span::default(),
+                    refutable: true,
+                    known_valid_scrutinee: true,
+                };
+
+                let Some(real_target) =
+                    self.static_pattern_match(&cx, value, &*scope.arms, &scope.built_match_tree)
+                else {
+                    // self.tcx.dcx().emit_fatal()
+                    todo!()
                 };
 
                 self.block_context.push(BlockFrame::SubExpr);

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -314,7 +314,8 @@ impl IntRange {
         IntRange { lo, hi }
     }
 
-    fn is_subrange(&self, other: &Self) -> bool {
+    #[inline]
+    pub fn is_subrange(&self, other: &Self) -> bool {
         other.lo <= self.lo && self.hi <= other.hi
     }
 

--- a/tests/ui/loop-match/integer-patterns.rs
+++ b/tests/ui/loop-match/integer-patterns.rs
@@ -6,26 +6,21 @@
 #![feature(loop_match)]
 
 fn main() {
-    let mut state = 0;
+    let mut state = 0i32;
     #[loop_match]
     'a: loop {
         state = 'blk: {
             match state {
                 -1 => {
-                    if true {
-                        #[const_continue]
-                        break 'blk 2;
-                    } else {
-                        #[const_continue]
-                        break 'blk 0;
-                    }
+                    #[const_continue]
+                    break 'blk 2;
                 }
                 0 => {
                     #[const_continue]
                     break 'blk -1;
                 }
                 2 => break 'a,
-                _ => break 'a,
+                _ => unreachable!("weird value {:?}", state),
             }
         }
     }


### PR DESCRIPTION
this is currently incomplete, but what do you think of this approach? The idea is to do all of the static pattern matching when we actually hit a `const_continue`, and just use the standard pattern match lowering. I think this simplifies the problem greatly and makes it much easier to support more patterns.

edit: it's complete now and I really like it.
