### PR TITLE
error on constant that is too generic

### DIFF
--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -84,10 +84,14 @@ mir_build_call_to_unsafe_fn_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
 
 mir_build_confused = missing patterns are not covered because `{$variable}` is interpreted as a constant pattern, not a new variable
 
+mir_build_const_continue_bad_const = could not determine the target branch for this `#[const_continue]`
+    .label = this value is too generic
+    .note = the value must be a literal or a monomorphic const
+
 mir_build_const_continue_missing_value = a `#[const_continue]` must break to a label with a value
 
 mir_build_const_continue_unknown_jump_target = the target of this `#[const_continue]` is not statically known
-    .note = this value must be an integer or enum literal
+    .label = this value must be a literal or a monomorphic const
 
 mir_build_const_defined_here = constant defined here
 

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -239,7 +239,7 @@ mir_build_loop_match_missing_assignment =
 
 mir_build_loop_match_unsupported_type =
     this `#[loop_match]` state value has type `{$ty}`, which is not supported
-    .note = only integers and enums without fields are supported
+    .note = only integers, floats, bool, char, and enums without fields are supported
 
 mir_build_lower_range_bound_must_be_less_than_or_equal_to_upper =
     lower range bound must be less than or equal to upper

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -255,7 +255,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 fn is_supported_loop_match_type(ty: Ty<'_>) -> bool {
                     match ty.kind() {
-                        ty::Uint(_) | ty::Int(_) | ty::Bool | ty::Char => true,
+                        ty::Uint(_) | ty::Int(_) | ty::Float(_) | ty::Bool | ty::Char => true,
                         ty::Adt(adt_def, _) => match adt_def.adt_kind() {
                             ty::AdtKind::Struct | ty::AdtKind::Union => false,
                             ty::AdtKind::Enum => {

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -21,6 +21,7 @@ use rustc_middle::ty::{
     self, CanonicalUserTypeAnnotation, Ty, TypeVisitableExt, ValTree, ValTreeKind,
 };
 use rustc_middle::{bug, span_bug};
+use rustc_pattern_analysis::constructor::RangeEnd;
 use rustc_pattern_analysis::rustc::{DeconstructedPat, RustcPatCtxt};
 use rustc_span::{BytePos, Pos, Span, Symbol, sym};
 use tracing::{debug, instrument};
@@ -1892,7 +1893,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         debug!("expanding or-pattern: candidate={:#?}\npats={:#?}", candidate, pats);
         candidate.or_span = Some(match_pair.pattern_span);
         candidate.subcandidates = pats
-            .into_vec()
             .into_iter()
             .map(|flat_pat| Candidate::from_flat_pat(flat_pat, candidate.has_guard))
             .collect();
@@ -2976,6 +2976,34 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 Ok(actual_value) => *pattern_value == actual_value,
                 Err(()) => bug!("bool value with invalid bits"),
             },
+            Constructor::F16Range(l, h, end) => {
+                let actual = valtree.unwrap_leaf().to_f16();
+                match end {
+                    RangeEnd::Included => (*l..=*h).contains(&actual),
+                    RangeEnd::Excluded => (*l..*h).contains(&actual),
+                }
+            }
+            Constructor::F32Range(l, h, end) => {
+                let actual = valtree.unwrap_leaf().to_f32();
+                match end {
+                    RangeEnd::Included => (*l..=*h).contains(&actual),
+                    RangeEnd::Excluded => (*l..*h).contains(&actual),
+                }
+            }
+            Constructor::F64Range(l, h, end) => {
+                let actual = valtree.unwrap_leaf().to_f64();
+                match end {
+                    RangeEnd::Included => (*l..=*h).contains(&actual),
+                    RangeEnd::Excluded => (*l..*h).contains(&actual),
+                }
+            }
+            Constructor::F128Range(l, h, end) => {
+                let actual = valtree.unwrap_leaf().to_f128();
+                match end {
+                    RangeEnd::Included => (*l..=*h).contains(&actual),
+                    RangeEnd::Excluded => (*l..*h).contains(&actual),
+                }
+            }
             Constructor::Wildcard => true,
 
             // These we may eventually support:
@@ -2984,10 +3012,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | Constructor::Slice(_)
             | Constructor::UnionField
             | Constructor::Or
-            | Constructor::F16Range(..)
-            | Constructor::F32Range(..)
-            | Constructor::F64Range(..)
-            | Constructor::F128Range(..)
             | Constructor::Str(_) => bug!("unsupported pattern constructor {:?}", pat.ctor()),
 
             // These should never occur here:

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -14,13 +14,11 @@ use rustc_abi::VariantIdx;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir::{BindingMode, ByRef, LetStmt, LocalSource, Node};
+use rustc_middle::bug;
 use rustc_middle::middle::region;
 use rustc_middle::mir::{self, *};
 use rustc_middle::thir::{self, *};
-use rustc_middle::ty::{
-    self, CanonicalUserTypeAnnotation, Ty, TypeVisitableExt, ValTree, ValTreeKind,
-};
-use rustc_middle::{bug, span_bug};
+use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty, ValTree, ValTreeKind};
 use rustc_pattern_analysis::constructor::RangeEnd;
 use rustc_pattern_analysis::rustc::{DeconstructedPat, RustcPatCtxt};
 use rustc_span::{BytePos, Pos, Span, Symbol, sym};
@@ -2871,7 +2869,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub(crate) fn static_pattern_match(
         &self,
         cx: &RustcPatCtxt<'_, 'tcx>,
-        constant: ConstOperand<'tcx>,
+        valtree: ValTree<'tcx>,
         arms: &[ArmId],
         built_match_tree: &BuiltMatchTree<'tcx>,
     ) -> Option<BasicBlock> {
@@ -2879,6 +2877,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         for (&arm_id, branch) in it {
             let pat = cx.lower_pat(&*self.thir.arms[arm_id].pattern);
 
+            // Peel off or-patterns if they exist.
             if let rustc_pattern_analysis::rustc::Constructor::Or = pat.ctor() {
                 for pat in pat.iter_fields() {
                     // For top-level or-patterns (the only ones we accept right now), when the
@@ -2890,12 +2889,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         .or_else(|| branch.sub_branches.last())
                         .unwrap();
 
-                    match self.static_pattern_match_help(constant, &pat.pat) {
+                    match self.static_pattern_match_inner(valtree, &pat.pat) {
                         true => return Some(sub_branch.success_block),
                         false => continue,
                     }
                 }
-            } else if self.static_pattern_match_help(constant, &pat) {
+            } else if self.static_pattern_match_inner(valtree, &pat) {
                 return Some(branch.sub_branches[0].success_block);
             }
         }
@@ -2903,52 +2902,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         None
     }
 
-    /// Based on `FunctionCx::eval_unevaluated_mir_constant_to_valtree`.
-    fn eval_unevaluated_mir_constant_to_valtree(
+    /// Helper for [`Self::static_pattern_match`]. It does not recurse, meaning that it does not
+    /// handle or-patterns, or patterns for types with fields.
+    fn static_pattern_match_inner(
         &self,
-        constant: ConstOperand<'tcx>,
-    ) -> (ty::ValTree<'tcx>, Ty<'tcx>) {
-        assert!(!constant.const_.ty().has_param());
-        let (uv, ty) = match constant.const_ {
-            mir::Const::Unevaluated(uv, ty) => (uv.shrink(), ty),
-            mir::Const::Ty(_, c) => match c.kind() {
-                // A constant that came from a const generic but was then used as an argument to
-                // old-style simd_shuffle (passing as argument instead of as a generic param).
-                ty::ConstKind::Value(cv) => return (cv.valtree, cv.ty),
-                other => span_bug!(constant.span, "{other:#?}"),
-            },
-            mir::Const::Val(mir::ConstValue::Scalar(mir::interpret::Scalar::Int(val)), ty) => {
-                return (ValTree::from_scalar_int(self.tcx, val), ty);
-            }
-            // We should never encounter `Const::Val` unless MIR opts (like const prop) evaluate
-            // a constant and write that value back into `Operand`s. This could happen, but is
-            // unlikely. Also: all users of `simd_shuffle` are on unstable and already need to take
-            // a lot of care around intrinsics. For an issue to happen here, it would require a
-            // macro expanding to a `simd_shuffle` call without wrapping the constant argument in a
-            // `const {}` block, but the user pass through arbitrary expressions.
-
-            // FIXME(oli-obk): Replace the magic const generic argument of `simd_shuffle` with a
-            // real const generic, and get rid of this entire function.
-            other => span_bug!(constant.span, "{other:#?}"),
-        };
-
-        match self.tcx.const_eval_resolve_for_typeck(self.typing_env(), uv, constant.span) {
-            Ok(Ok(valtree)) => (valtree, ty),
-            Ok(Err(ty)) => span_bug!(constant.span, "could not convert {ty:?} to a valtree"),
-            Err(_) => span_bug!(constant.span, "unable to evaluate this constant"),
-        }
-    }
-
-    fn static_pattern_match_help(
-        &self,
-        constant: ConstOperand<'tcx>,
+        valtree: ty::ValTree<'tcx>,
         pat: &DeconstructedPat<'_, 'tcx>,
     ) -> bool {
         use rustc_pattern_analysis::constructor::{IntRange, MaybeInfiniteInt};
         use rustc_pattern_analysis::rustc::Constructor;
-
-        let (valtree, ty) = self.eval_unevaluated_mir_constant_to_valtree(constant);
-        assert!(!ty.has_param());
 
         match pat.ctor() {
             Constructor::Variant(variant_index) => {

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -866,7 +866,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ty::Adt(adt_def, _) if adt_def.is_enum() => {
                 (state_ty.discriminant_ty(self.tcx), Rvalue::Discriminant(scope.state_place))
             }
-            ty::Uint(_) | ty::Int(_) | ty::Bool | ty::Char => {
+            ty::Uint(_) | ty::Int(_) | ty::Float(_) | ty::Bool | ty::Char => {
                 (state_ty, Rvalue::Use(Operand::Copy(scope.state_place)))
             }
             _ => span_bug!(state_decl.source_info.span, "unsupported #[loop_match] state"),

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -83,13 +83,14 @@ that contains only loops and breakable blocks. It tracks where a `break`,
 
 use std::mem;
 
+use interpret::ErrorHandled;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::HirId;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::middle::region;
-use rustc_middle::mir::*;
+use rustc_middle::mir::{self, *};
 use rustc_middle::thir::{AdtExpr, AdtExprBase, ArmId, ExprId, ExprKind, LintLevel};
-use rustc_middle::ty::ValTree;
+use rustc_middle::ty::{Ty, TypeVisitableExt, ValTree};
 use rustc_middle::{bug, span_bug, ty};
 use rustc_pattern_analysis::rustc::RustcPatCtxt;
 use rustc_session::lint::Level;
@@ -99,7 +100,7 @@ use tracing::{debug, instrument};
 
 use super::matches::BuiltMatchTree;
 use crate::builder::{BlockAnd, BlockAndExtension, BlockFrame, Builder, CFG};
-use crate::errors::ConstContinueUnknownJumpTarget;
+use crate::errors::{ConstContinueBadConst, ConstContinueUnknownJumpTarget};
 
 #[derive(Debug)]
 pub(crate) struct Scopes<'tcx> {
@@ -813,6 +814,42 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.cfg.start_new_block().unit()
     }
 
+    /// Based on `FunctionCx::eval_unevaluated_mir_constant_to_valtree`.
+    fn eval_unevaluated_mir_constant_to_valtree(
+        &self,
+        constant: ConstOperand<'tcx>,
+    ) -> Result<(ty::ValTree<'tcx>, Ty<'tcx>), interpret::ErrorHandled> {
+        assert!(!constant.const_.ty().has_param());
+        let (uv, ty) = match constant.const_ {
+            mir::Const::Unevaluated(uv, ty) => (uv.shrink(), ty),
+            mir::Const::Ty(_, c) => match c.kind() {
+                // A constant that came from a const generic but was then used as an argument to
+                // old-style simd_shuffle (passing as argument instead of as a generic param).
+                ty::ConstKind::Value(cv) => return Ok((cv.valtree, cv.ty)),
+                other => span_bug!(constant.span, "{other:#?}"),
+            },
+            mir::Const::Val(mir::ConstValue::Scalar(mir::interpret::Scalar::Int(val)), ty) => {
+                return Ok((ValTree::from_scalar_int(self.tcx, val), ty));
+            }
+            // We should never encounter `Const::Val` unless MIR opts (like const prop) evaluate
+            // a constant and write that value back into `Operand`s. This could happen, but is
+            // unlikely. Also: all users of `simd_shuffle` are on unstable and already need to take
+            // a lot of care around intrinsics. For an issue to happen here, it would require a
+            // macro expanding to a `simd_shuffle` call without wrapping the constant argument in a
+            // `const {}` block, but the user pass through arbitrary expressions.
+
+            // FIXME(oli-obk): Replace the magic const generic argument of `simd_shuffle` with a
+            // real const generic, and get rid of this entire function.
+            other => span_bug!(constant.span, "{other:#?}"),
+        };
+
+        match self.tcx.const_eval_resolve_for_typeck(self.typing_env(), uv, constant.span) {
+            Ok(Ok(valtree)) => Ok((valtree, ty)),
+            Ok(Err(ty)) => span_bug!(constant.span, "could not convert {ty:?} to a valtree"),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Sets up the drops for jumping from `block` to `scope`.
     pub(crate) fn break_const_continuable_scope(
         &mut self,
@@ -890,8 +927,21 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             known_valid_scrutinee: true,
         };
 
+        let valtree = match self.eval_unevaluated_mir_constant_to_valtree(constant) {
+            Ok((valtree, ty)) => {
+                // Defensively check that the type is monomorphic.
+                assert!(!ty.has_param());
+
+                valtree
+            }
+            Err(ErrorHandled::Reported(..)) => return self.cfg.start_new_block().unit(),
+            Err(ErrorHandled::TooGeneric(_)) => {
+                self.tcx.dcx().emit_fatal(ConstContinueBadConst { span: constant.span });
+            }
+        };
+
         let Some(real_target) =
-            self.static_pattern_match(&cx, constant, &*scope.arms, &scope.built_match_tree)
+            self.static_pattern_match(&cx, valtree, &*scope.arms, &scope.built_match_tree)
         else {
             self.tcx.dcx().emit_fatal(ConstContinueUnknownJumpTarget { span })
         };

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -1217,6 +1217,14 @@ pub(crate) struct LoopMatchArmWithGuard {
 }
 
 #[derive(Diagnostic)]
+#[diag(mir_build_const_continue_bad_const)]
+pub(crate) struct ConstContinueBadConst {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(mir_build_const_continue_missing_value)]
 pub(crate) struct ConstContinueMissingValue {
     #[primary_span]

--- a/tests/ui/loop-match/const-continue-to-polymorphic-const.rs
+++ b/tests/ui/loop-match/const-continue-to-polymorphic-const.rs
@@ -1,0 +1,29 @@
+// Test that a `#[const_continue]` that breaks on a polymorphic constant produces an error.
+// A polymorphic constant does not have a concrete value at MIR building time, and therefore the
+// `#[loop_match]~ desugaring can't handle such values.
+#![allow(incomplete_features)]
+#![feature(loop_match)]
+#![crate_type = "lib"]
+
+trait Foo {
+    const Target: u8;
+
+    fn test_u8(mut state: u8) -> &'static str {
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    0 => {
+                        #[const_continue]
+                        break 'blk Self::Target;
+                        //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                    }
+
+                    1 => return "bar",
+                    2 => return "baz",
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+}

--- a/tests/ui/loop-match/const-continue-to-polymorphic-const.stderr
+++ b/tests/ui/loop-match/const-continue-to-polymorphic-const.stderr
@@ -1,0 +1,8 @@
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/const-continue-to-polymorphic-const.rs:18:36
+   |
+LL |                         break 'blk Self::Target;
+   |                                    ^^^^^^^^^^^^ this value is too generic
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/loop-match/unsupported-type.stderr
+++ b/tests/ui/loop-match/unsupported-type.stderr
@@ -4,7 +4,7 @@ error: this `#[loop_match]` state value has type `Option<bool>`, which is not su
 LL |         state = 'blk: {
    |         ^^^^^
    |
-   = note: only integers and enums without fields are supported
+   = note: only integers, floats, bool, char, and enums without fields are supported
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/loop-match/valid-patterns.rs
+++ b/tests/ui/loop-match/valid-patterns.rs
@@ -17,6 +17,14 @@ fn main() {
     assert_eq!(character('b'), 'b');
     assert_eq!(character('c'), 'd');
     assert_eq!(character('d'), 'd');
+
+    assert_eq!(test_f32(1.0), core::f32::consts::PI);
+    assert_eq!(test_f32(2.5), core::f32::consts::PI);
+    assert_eq!(test_f32(4.0), 4.0);
+
+    assert_eq!(test_f64(1.0), core::f64::consts::PI);
+    assert_eq!(test_f64(2.5), core::f64::consts::PI);
+    assert_eq!(test_f64(4.0), 4.0);
 }
 
 fn integer(mut state: i32) -> i32 {
@@ -70,6 +78,38 @@ fn character(mut state: char) -> char {
                     #[const_continue]
                     break 'blk 'd';
                 }
+                _ => return state,
+            }
+        }
+    }
+}
+
+fn test_f32(mut state: f32) -> f32 {
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                1.0 => {
+                    #[const_continue]
+                    break 'blk 2.5;
+                }
+                2.0..3.0 => return core::f32::consts::PI,
+                _ => return state,
+            }
+        }
+    }
+}
+
+fn test_f64(mut state: f64) -> f64 {
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                1.0 => {
+                    #[const_continue]
+                    break 'blk 2.5;
+                }
+                2.0..3.0 => return core::f64::consts::PI,
                 _ => return state,
             }
         }


### PR DESCRIPTION
also support floats so that we support all scalars. 

I moved some code around so that the error can be generated at a good point, and we no longer const evaluate the value for each arm of the match but just once at the top.